### PR TITLE
Export `NonNullish` type

### DIFF
--- a/.changeset/empty-cameras-joke.md
+++ b/.changeset/empty-cameras-joke.md
@@ -1,0 +1,5 @@
+---
+'aint': minor
+---
+
+Export NotNullish type

--- a/.changeset/empty-cameras-joke.md
+++ b/.changeset/empty-cameras-joke.md
@@ -2,4 +2,4 @@
 'aint': minor
 ---
 
-Export NotNullish type
+Export NonNullish type

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 export { isNotNull } from './isNotNull';
 export { isNotUndefined } from './isNotUndefined';
 export { isNotNullish } from './isNotNullish';
-export type { NotNullish } from './isNotNullish';
+export type { NonNullish } from './isNotNullish';
 
 export { isNotEmptyString } from './isNotEmptyString';
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 export { isNotNull } from './isNotNull';
 export { isNotUndefined } from './isNotUndefined';
 export { isNotNullish } from './isNotNullish';
+export type { NotNullish } from './isNotNullish';
 
 export { isNotEmptyString } from './isNotEmptyString';
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,6 @@
 export { isNotNull } from './isNotNull';
 export { isNotUndefined } from './isNotUndefined';
-export { isNotNullish } from './isNotNullish';
-export type { NonNullish } from './isNotNullish';
+export { type NonNullish, isNotNullish } from './isNotNullish';
 
 export { isNotEmptyString } from './isNotEmptyString';
 

--- a/lib/isNotNullish.ts
+++ b/lib/isNotNullish.ts
@@ -1,5 +1,5 @@
-export function isNotNullish<T>(
-  value: T
-): value is Exclude<T, null | undefined> {
+export type NotNullish<T> = Exclude<T, null | undefined>;
+
+export function isNotNullish<T>(value: T): value is NotNullish<T> {
   return value != null;
 }

--- a/lib/isNotNullish.ts
+++ b/lib/isNotNullish.ts
@@ -1,5 +1,5 @@
-export type NotNullish<T> = Exclude<T, null | undefined>;
+export type NonNullish<T> = Exclude<T, null | undefined>;
 
-export function isNotNullish<T>(value: T): value is NotNullish<T> {
+export function isNotNullish<T>(value: T): value is NonNullish<T> {
   return value != null;
 }


### PR DESCRIPTION
Exports the `NonNullish` type from the associated predicate to allow for greater control when implementing custom filtering functions using `isNotNullish()`.