### PR TITLE
Export NonEmptyArray from a single statement

### DIFF
--- a/.changeset/tall-foxes-hope.md
+++ b/.changeset/tall-foxes-hope.md
@@ -1,0 +1,5 @@
+---
+'aint': minor
+---
+
+Export `NonEmptyArray` type from a single statement

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,5 +4,4 @@ export { type NonNullish, isNotNullish } from './isNotNullish';
 
 export { isNotEmptyString } from './isNotEmptyString';
 
-export { isNotEmptyArray } from './isNotEmptyArray';
-export type { NonEmptyArray } from './isNotEmptyArray';
+export { type NonEmptyArray, isNotEmptyArray } from './isNotEmptyArray';


### PR DESCRIPTION
Updates the `NonEmptyArray` type export to be in a single, more concise, export declaration for consistency.