### PR TITLE
fix: export of types to work with node16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,16 @@
   "exports": {
     ".": {
       "node": {
-        "import": "./build/node/esm/index.js",
-        "require": "./build/node/cjs/index.js"
+        "import": {
+          "types": "./build/types/index.d.ts",
+          "default": "./build/node/esm/index.js"
+        },
+        "require": {
+          "types": "./build/types/index.d.ts",
+          "default": "./build/node/cjs/index.js"
+        }
       },
+      "types": "./build/types/index.d.ts",
       "default": "./build/browser/esm/index.js"
     }
   },


### PR DESCRIPTION
fixes #18

before: https://arethetypeswrong.github.io/?p=aint%400.5.1
![image](https://github.com/causaly/aint/assets/8623409/f220796f-ae50-42cc-a394-c89a6cba15f0)


after: 
![image](https://github.com/causaly/aint/assets/8623409/7e70cbcb-d94a-4fa9-9dc1-dea6b92897d0)

npm module exporting am i right? :3

