### PR TITLE
ci: add yarn changeset version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
+          version: yarn changeset version
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The documentation at https://github.com/changesets/action?tab=readme-ov-file#with-yarn-2--plugnplay seems to suggest later versions of yarn need a custom version command to resolve the CLI. I'm not sure this is the issue but I can try..?