### PR TITLE
Csly 8518 un break release alternative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+.yarn
+
 # other
 coverage

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,5 @@
+nodeLinker: node-modules
+
+npmRegistries:
+  //npm.pkg.github.com:
+    npmAuthToken: "${NPM_TOKEN}"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,1 @@
 nodeLinker: node-modules
-
-npmRegistries:
-  //npm.pkg.github.com:
-    npmAuthToken: "${NPM_TOKEN}"


### PR DESCRIPTION
This builds on the fix by explicitly setting `nodeLinker` to eliminate `.pnp.loader.mjs` and `.pnp.cjs` files.