### PR TITLE
chore: update contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,22 @@
       "name": "Dimitrios Lytras",
       "email": "dnlytras@gmail.com",
       "url": "https://dnlytras.com"
+    },
+    {
+      "name": "Konstantinos Liberopoulos",
+      "email": "libekonst@gmail.com"
+    },
+    {
+      "name": "Mark Goodwin",
+      "email": "mark@computerist.org"
+    },
+    {
+      "name": "Nikos Kalogridis",
+      "email": "nikos.kalogridis@gmail.com"
+    },
+    {
+      "name": "Stavros Tsourlidakis",
+      "email": "s.tsourlidakis@hotmail.com"
     }
   ],
   "sideEffects": false,


### PR DESCRIPTION
It seems the node version is hardcoded in npm project settings?!

Oh well, revving the contributors gets us to try the whole build machinery